### PR TITLE
Search documentation - snippet is missing `relUrl`

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -33,7 +33,8 @@ your search index. Alternatively, you can create the file manually in the
     "id": "{{ forloop.index0 }}",
     "title": "{{ page.title | xml_escape }}",
     "content": "{{ page.content | markdownify | strip_html | xml_escape | remove: 'Table of contents' | remove: page.title | strip_newlines | replace: '\', ' '}}",
-    "url": "{{ page.url | xml_escape }}"
+    "url": "{{ page.url | absolute_url | xml_escape }}",
+    "relUrl": "{{ page.url | xml_escape }}"
   }{% if forloop.last %}{% else %},
   {% endif %}{% endfor %}
 }{% endraw %}


### PR DESCRIPTION
The code snippet on the search documentation is super-useful, but unfortunately missing the `relUrl` parameter in each search result, and the `url` parameter is not an absolute URL. Without `relUrl` the Lunr.js search results have an ugly 'undefined' element where the relUrl value should be.

This updates to match the formatted output of `search.rake`