### PR TITLE
Nav exclude hook

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,7 +1,8 @@
 <nav>
   <ul class="navigation-list">
   {% assign pages_list = site.html_pages | sort:"nav_order" %}
-  {% for node in pages_list %}
+    {% for node in pages_list %}
+    {% unless node.nav_exclude %}
       <li class="navigation-list-item{% if page.url == node.url %} active{% endif %} js-side-nav-item">
         {% if node.parent == nil or node.has_children == true %}
         <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url or (page.parent != nil and page.parent == node.parent) %} active{% endif %}">{{ node.title }}</a>
@@ -19,6 +20,7 @@
           {% endif %}
         {% endif %}
       </li>
-  {% endfor %}
+    {% endunless %}
+    {% endfor %}
   </ul>
 </nav>

--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -11,7 +11,7 @@ code {
   border-radius: $border-radius;
 }
 
-.highlight {
+pre.highlight {
   padding: $sp-3;
   margin-bottom: 0;
   background-color: $grey-lt-000;

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -4,6 +4,12 @@
 // stylelint-disable selector-no-type, max-nesting-depth, selector-max-compound-selectors, selector-max-type
 
 .page-content {
+  a {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
   ul,
   ol {
     padding-left: 1.5em;

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -5,9 +5,9 @@
 
 .page-content {
   a {
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden;
   }
 
   ul,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ nav_order: 2
 
 # Configuration
 
-Just the Docs has some specific configuration parameters that can be definied in your Jekyll site's `config.yml` file.
+Just the Docs has some specific configuration parameters that can be definied in your Jekyll site's `_config.yml` file.
 
 ## Search enabled
 

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -35,6 +35,18 @@ nav_order: 4
 ---
 ```
 
+### Excluding pages
+
+For specific pages that you do not wish to include in the main navigation, e.g. a 404 page. Use the `nav_exclude: true` parameter in the YAML front matter for that page.
+
+```yaml
+---
+layout: default
+title: 404
+nav_exclude: true
+---
+```
+
 ### Pages with children
 
 Sometimes you will want to create a page with many children (a section). To accomplish this you need to a few things. First, it is recommended that you keep pages that are related in a directory together... For example, in these docs, we keep all of the written documentation in the `./docs` directory and each of the sections in subdirectories like `./docs/ui-components` and `./docs/utilities`. This gives is an organization like:

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -27,6 +27,8 @@ By default, all pages will appear as top level pages in the main nav.
 
 To specify a page order, use the `nav_order` variable in your pages' YAML front matter.
 
+#### Example
+{: .no_toc }
 ```yaml
 ---
 layout: default
@@ -39,6 +41,8 @@ nav_order: 4
 
 For specific pages that you do not wish to include in the main navigation, e.g. a 404 page. Use the `nav_exclude: true` parameter in the YAML front matter for that page.
 
+#### Example
+{: .no_toc }
 ```yaml
 ---
 layout: default
@@ -87,12 +91,14 @@ On the parent pages, add 3 YAML front matter variables:
 {: .no_toc }
 
 ```yaml
+---
 layout: default
 title: UI Components
 nav_order: 2
 has_children: true
 parent: UI Components
 permalink: /ui-components
+---
 ```
 
 Here we're setting up the UI Components landing page that is available at `/ui-components`, has children and is ordered second in the main nav.
@@ -104,10 +110,12 @@ On child pages, simply set the `parent:` YAML front matter to whatever the paren
 #### Example
 {: .no_toc }
 ```yaml
+---
 layout: default
 title: Buttons
 parent: UI Components
 nav_order: 2
+---
 ```
 
 The Buttons page appears a child of UI Components and appears second in the UI Components section.

--- a/docs/ui-components/buttons.md
+++ b/docs/ui-components/buttons.md
@@ -21,7 +21,6 @@ nav_order: 2
 ### Links that look like buttons
 
 <div class="code-example" markdown="1">
-
 [Link button](http://example.com/){: .btn }
 
 [Link button](http://example.com/){: .btn .btn-purple }
@@ -32,7 +31,6 @@ nav_order: 2
 
 </div>
 ```markdown
-
 [Link button](http://example.com/){: .btn }
 
 [Link button](http://example.com/){: .btn .btn-purple }

--- a/docs/ui-components/labels.md
+++ b/docs/ui-components/labels.md
@@ -31,7 +31,6 @@ Deprecated
 
 </div>
 ```markdown
-
 Default label
 {: .label }
 
@@ -49,5 +48,4 @@ Coming soon
 
 Deprecated
 {: .label .label-red}
-
 ```

--- a/index.md
+++ b/index.md
@@ -20,7 +20,14 @@ Just the Docs gives your documentation a jumpstart with a responsive Jekyll them
 ### Dependencies
 Just the Docs is built for [Jekyll](https://jekyllrb.com), a static site generator. View the [quick start guide](https://jekyllrb.com/docs/quickstart/) for more information. Just the Docs requires no special Jekyll plugins and can run on GitHub Pages standard Jekyll compiler.
 
-### Installation
+### Quick start: Use as a GitHub Pages remote theme
+1. Add Just the Docs to your Jekyll site's `_config.yml` as a remote theme
+```yaml
+remote_theme: pmarsceill/just-the-docs
+```
+<small>You must have GitHub pages enabled on your repo, one or more markdown files, and a `_config.yml` file. [See an example repository](https://github.com/pmarsceill/jtd-remote)</small>
+
+### Local installation: Use the gem-based theme
 1. Install the Ruby Gem
 ```bash
 $ gem install just-the-docs
@@ -29,7 +36,7 @@ $ gem install just-the-docs
 # .. or add it to your your Jekyll site’s Gemfile
 gem "just-the-docs"
 ```
-2. Add Just the Docs to your Jekyll site’s `config.yml`
+2. Add Just the Docs to your Jekyll site’s `_config.yml`
 ```yaml
 theme: "just-the-docs"
 ```
@@ -46,6 +53,10 @@ $ jekyll serve
 $ bundle exec jekyll serve
 ```
 4. Point your web browser to [http://localhost:4000](http://localhost:4000)
+
+### Configure Just the Docs
+- [See configuration options]({{ site.baseurl }}{% link docs/configuration.md %})
+
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Just the Docs gives your documentation a jumpstart with a responsive Jekyll them
 Just the Docs is built for [Jekyll](https://jekyllrb.com), a static site generator. View the [quick start guide](https://jekyllrb.com/docs/quickstart/) for more information. Just the Docs requires no special Jekyll plugins and can run on GitHub Pages standard Jekyll compiler.
 
 ### Quick start: Use as a GitHub Pages remote theme
-1. Add Just the Docs to your Jekyll site's `_config.yml` as a remote theme
+1. Add Just the Docs to your Jekyll site's `_config.yml` as a [remote theme](https://blog.github.com/2017-11-29-use-any-theme-with-github-pages/)
 ```yaml
 remote_theme: pmarsceill/just-the-docs
 ```


### PR DESCRIPTION
This adds a conditional that checks for `nav_exclude` to be set to `true` to exclude a page from the main nav.

closes #21 