### PR TITLE
Indented the title for aux_link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ search_enabled: true
 # Aux links for the upper right navigation
 aux_links:
     "Just the Docs on GitHub":
-    - "//github.com/pmarsceill/just-the-docs"
+      - "//github.com/pmarsceill/just-the-docs"
 ```
 
 ## Color scheme

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ search_enabled: true
 ```yml
 # Aux links for the upper right navigation
 aux_links:
-"Just the Docs on GitHub":
+    "Just the Docs on GitHub":
     - "//github.com/pmarsceill/just-the-docs"
 ```
 


### PR DESCRIPTION
The indent is required for the aux links to work.