### PR TITLE
Fixes nested lists

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -15,9 +15,6 @@
   ul,
   ol {
     padding-left: 1.5em;
-  }
-
-  ol, ul {
     counter-reset: step-counter;
     list-style-type: none;
     li {

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -17,13 +17,16 @@
     padding-left: 1.5em;
   }
 
-  ol {
-    list-style-type: none;
+  ol, ul {
     counter-reset: step-counter;
-
+    list-style-type: none;
     li {
       position: relative;
+    }
+  }
 
+  ol {
+    li {
       &::before {
         position: absolute;
         top: 0.2em;
@@ -37,29 +40,37 @@
           top: 0.11em;
         }
       }
-
-      ol {
-        counter-reset: sub-counter;
-
-        li {
-          &::before {
-            content: counter(sub-counter, lower-alpha);
-            counter-increment: sub-counter;
-          }
-        }
-      }
     }
   }
-
   ul {
-    list-style: none;
-
     li {
       &::before {
         position: absolute;
         margin-left: -1.5em;
         color: $grey-dk-000;
         content: "•";
+      }
+    }
+  }
+  li {
+    ol {
+      counter-reset: sub-counter;
+      li {
+        &::before {
+          content: counter(sub-counter, lower-alpha);
+          counter-increment: sub-counter;
+          margin-left: 0;
+        }
+      }
+    }
+    ul {
+      counter-reset: sub-counter;
+      li {
+        &::before {
+          // Keeps ordered lists with nested unordered lists from getting misnumbered.
+          counter-increment: sub-counter;
+          margin-left: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
Nested lists are pretty critical for documentation, and the current list implementation has a couple issues with them:

1. They don't get indented properly.
2. Adding a ul within an ol messes up the numbering on the original ol.

I tweaked the existing implementation (counters) rather than reverting to standard ol numbering, because I like how your numbering doesn't include periods.

I wasn't able to detect any regressions in content nor in TOCs, but let me know if you spot anything and I'll see what I can do. Here's some test Markdown:

```
1. Click **Button**.
1. **Create**.
1. Specify a name and schedule.
1. Select one or more indices, or specify `*` for all indices.
1. Define in one of two ways: visually or using a query.

   - Visual definition works well for some things...

   - Query definition works well for others...

     1. More stuff.

     1. More.
     
     1. Last one.

1. To define visually, select **Define using graph**. Then choose `something` or `something else`.

   To use a query, select **Define using query**, add your query (using some language or another), and test it using the **Run** button.

   Everything runs on a set schedule.

1. Click **Create**.

   1. More stuff.

   1. More.

   1. Last one.

1. We're almost done.
1. Yes, we're done.

A brand new list!

- Click **Button**.
- **Create**.
- Specify a name and schedule.

  1. Visual definition works well for some things...

  1. Query definition works well for others...

- To define visually, select **Define using graph**. Then choose `something` or `something else`.

  To use a query, select **Define using query**, add your query (using some language or another), and test it using the **Run** button.

  Everything runs on a set schedule.

- Click **Create**.
```