### PR TITLE
search-data path fix

### DIFF
--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -54,7 +54,7 @@ function initSearch() {
 
   jsPath = source.replace('just-the-docs.js', '');
 
-  jsonPath = jsPath + '/search-data.json';
+  jsonPath = jsPath + 'search-data.json';
 
   var request = new XMLHttpRequest();
   request.open('GET', jsonPath, true);


### PR DESCRIPTION
Using the latest version, was seeing a 404 error for "/assets/js//search-data.json". Looks like the double slash was the culprit. No longer seeing the error with this fix.

However, search still doesn't quite work like what I'm seeing in the example (https://user-images.githubusercontent.com/896475/47384541-89053c80-d6d5-11e8-98dc-dba16e192de9.gif). Instead, when searching I'll see results for the first few characters, but the dropdown disappears after more than 3 characters—even when results should be present.