### PR TITLE
page layout also used out of the box by Jekyll

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{{ content }}


### PR DESCRIPTION
Suggesting page, since `about.md` uses it for new Jekyll installs as well.