### PR TITLE
Improve search data generation

### DIFF
--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -7,6 +7,6 @@
     "content": "{{ page.content | newline_to_br | replace: '<br />', ' ' | replace: '</h1>', ' ' | strip_newlines | markdownify | strip_html | remove: 'Table of contents' | xml_excape | escape | replace: '\', ' ' | replace: '```', '' | replace: '   ', ' ' | replace: '    ', ' ' | remove: '---' | remove: '#####' | remove: '####' | remove: '###' | remove: '##' | strip_newlines }}",
     "url": "{{ page.url | absolute_url | xml_escape }}",
     "relUrl": "{{ page.url | xml_escape }}"
-  }{% if forloop.last %}{% else %},{% endif %}
+  }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }

--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -3,10 +3,10 @@
 {
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
-    "title": "{{ page.title | xml_escape }}",
+    "title": "{{ page.title | replace: '&amp;', '&' }}",
     "content": "{{ page.content | markdownify | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | normalize_whitespace }}",
-    "url": "{{ page.url | absolute_url | xml_escape }}",
-    "relUrl": "{{ page.url | xml_escape }}"
+    "url": "{{ page.url | absolute_url }}",
+    "relUrl": "{{ page.url }}"
   }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }

--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -4,7 +4,7 @@
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
     "title": "{{ page.title | xml_escape }}",
-    "content": "{{ page.content | newline_to_br | replace: '<br />', ' ' | replace: '</h1>', ' ' | strip_newlines | markdownify | strip_html | remove: 'Table of contents' | xml_excape | escape | replace: '\', ' ' | replace: '```', '' | replace: '   ', ' ' | replace: '    ', ' ' | remove: '---' | remove: '#####' | remove: '####' | remove: '###' | remove: '##' | strip_newlines }}",
+    "content": "{{ page.content | markdownify | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | normalize_whitespace }}",
     "url": "{{ page.url | absolute_url | xml_escape }}",
     "relUrl": "{{ page.url | xml_escape }}"
   }{% unless forloop.last %},{% endunless %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,18 +6,18 @@ nav_order: 2
 
 # Configuration
 
-Just the Docs has some specific configuration parameters that can be definied in your Jekyll site's `_config.yml` file.
+Just the Docs has some specific configuration parameters that can be defined in your Jekyll site's `_config.yml` file.
 
 ## Search enabled
 
-```yml
+```yaml
 # Enable or disable the site search
 search_enabled: true
 ```
 
 ## Aux links
 
-```yml
+```yaml
 # Aux links for the upper right navigation
 aux_links:
     "Just the Docs on GitHub":
@@ -26,7 +26,7 @@ aux_links:
 
 ## Color scheme
 
-```yml
+```yaml
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: "dark"
 ```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -28,7 +28,7 @@ To enable a color scheme, set the `color_scheme` parameter in your site's `_conf
 #### Example
 {: .no_toc }
 
-```yml
+```yaml
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: "dark"
 ```
@@ -68,6 +68,6 @@ $link-color: $blue-000;
 // ...
 ```
 
-_Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependancies to fail.
+_Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependencies to fail.
 
 ---

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -200,7 +200,7 @@ To add a auxiliary navigation item to your site (in the upper right on all pages
 #### Example
 {: .no_toc }
 
-```yml
+```yaml
 # Aux links for the upper right navigation
 aux_links:
   "Just the Docs on GitHub":

--- a/docs/search.md
+++ b/docs/search.md
@@ -37,13 +37,13 @@ This command creates the `search-data.json` file that Jekyll uses to create your
 {% raw %}---
 ---
 {
-  {% for page in site.html_pages %}"{{ forloop.index0 }}": {
+  {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
     "title": "{{ page.title | xml_escape }}",
     "content": "{{ page.content | markdownify | strip_html | xml_escape | remove: 'Table of contents' | remove: page.title | strip_newlines | replace: '\', ' '}}",
     "url": "{{ page.url | absolute_url | xml_escape }}",
     "relUrl": "{{ page.url | xml_escape }}"
-  }{% if forloop.last %}{% else %},
+  }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }{% endraw %}
 ```

--- a/docs/search.md
+++ b/docs/search.md
@@ -33,8 +33,8 @@ $ bundle exec just-the-docs rake search:init
 
 This command creates the `search-data.json` file that Jekyll uses to create your search index. Alternatively, you can create the file manually in the `assets/js/` directory of your Jekyll site with this content:
 
-```{% raw %}
----
+```liquid
+{% raw %}---
 ---
 {
   {% for page in site.html_pages %}"{{ forloop.index0 }}": {
@@ -54,7 +54,7 @@ _Note: If you don't run this rake command or create this file manually, search w
 
 In your site's `_config.yml`, enable search:
 
-```yml
+```yaml
 # Enable or disable the site search
 search_enabled: true
 ```

--- a/docs/search.md
+++ b/docs/search.md
@@ -39,10 +39,10 @@ This command creates the `search-data.json` file that Jekyll uses to create your
 {
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
-    "title": "{{ page.title | xml_escape }}",
+    "title": "{{ page.title | replace: '&amp;', '&' }}",
     "content": "{{ page.content | markdownify | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | normalize_whitespace }}",
-    "url": "{{ page.url | absolute_url | xml_escape }}",
-    "relUrl": "{{ page.url | xml_escape }}"
+    "url": "{{ page.url | absolute_url }}",
+    "relUrl": "{{ page.url }}"
   }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }{% endraw %}

--- a/docs/search.md
+++ b/docs/search.md
@@ -40,7 +40,7 @@ This command creates the `search-data.json` file that Jekyll uses to create your
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
     "title": "{{ page.title | xml_escape }}",
-    "content": "{{ page.content | markdownify | strip_html | xml_escape | remove: 'Table of contents' | remove: page.title | strip_newlines | replace: '\', ' '}}",
+    "content": "{{ page.content | markdownify | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | normalize_whitespace }}",
     "url": "{{ page.url | absolute_url | xml_escape }}",
     "relUrl": "{{ page.url | xml_escape }}"
   }{% unless forloop.last %},{% endunless %}

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Patrick Marsceill"]
   spec.email         = ["patrick.marsceill@gmail.com"]
 
-  spec.summary       = %q{A nice looking, high customizable, responsive Jekyll theme for documention with built-in search.}
+  spec.summary       = %q{A nice looking, highly customizable, responsive Jekyll theme for documentation with built-in search.}
   spec.homepage      = "https://github.com/pmarsceill/just-the-docs"
   spec.license       = "MIT"
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -4,7 +4,7 @@ namespace :search do
     puts 'Creating search data json file...'
     mkdir_p 'assets/js'
     touch 'assets/js/search-data.json'
-    content = %Q[{{ page.content | markdownify | strip_html | xml_escape | remove: 'Table of contents' | strip_newlines | replace: '\\', ' ' }}]
+    content = %Q[{{ page.content | markdownify | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\\', ' ' | normalize_whitespace }}]
     puts 'Done.'
     puts 'Generating content...'
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -12,13 +12,13 @@ namespace :search do
       f.puts '---
 ---
 {
-  {% for page in site.html_pages %}"{{ forloop.index0 }}": {
+  {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
     "title": "{{ page.title | xml_escape }}",
     "content": "'+content+'",
     "url": "{{ page.url | absolute_url | xml_escape }}",
     "relUrl": "{{ page.url | xml_escape }}"
-  }{% if forloop.last %}{% else %},
+  }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }'
     end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -14,10 +14,10 @@ namespace :search do
 {
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
-    "title": "{{ page.title | xml_escape }}",
+    "title": "{{ page.title | replace: '&amp;', '&' }}",
     "content": "'+content+'",
-    "url": "{{ page.url | absolute_url | xml_escape }}",
-    "relUrl": "{{ page.url | xml_escape }}"
+    "url": "{{ page.url | absolute_url }}",
+    "relUrl": "{{ page.url }}"
   }{% unless forloop.last %},{% endunless %}
   {% endif %}{% endfor %}
 }'


### PR DESCRIPTION
With some experimentation I've come up with this shorter and cleaner search data pipeline: 

- `page.content` - fetches what should be the page's rendered HTML
- `markdownify` - there is a concurrency issue somewhere that causes the first dozen pages of `site.html_pages` to be returned as rendered HTML, and the rest as the original Markdown. This ensures that all page content has been converted to HTML.
- `strip_html` - removes all HTML tags
- `escape_once` - escapes all quotes, brackets, and other such characters to their HTML entity equivalents, but leaves alone ampersands that are already part of an escape sequence
- `remove: 'Table of contents'` - removes title text that doesn't count as content
- `remove: '```' | remove: '---'` - remove any leftover Markdown elements from within markup examples
- `replace: '\', ' '` - swap any backslashes with spaces
- `normalize_whitespace` - collapse all whitespace to a single space

This also updates the rake task and documentation page with the same content.