### PR TITLE
fix #80 - escape the single quotes in the string

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -14,8 +14,8 @@ namespace :search do
 {
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {
     "id": "{{ forloop.index0 }}",
-    "title": "{{ page.title | replace: '&amp;', '&' }}",
-    "content": "'+content+'",
+    "title": "{{ page.title | replace: \'&amp;\', \'&\' }}",
+    "content": "\'+content+\'",
     "url": "{{ page.url | absolute_url }}",
     "relUrl": "{{ page.url }}"
   }{% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
the single quotes in the string were unescaped and ruby attempted variable substitution of `amp` within it (which failed)