### PR TITLE
Add SEO and 'lang' param for `_config`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,3 +35,6 @@ color_scheme: nil
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
 ga_tracking: UA-2709176-10
+
+plugins:
+  - jekyll-seo-tag

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,4 +23,6 @@
   <script type="text/javascript" src="{{ "/assets/js/just-the-docs.js" | absolute_url }}"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en-us">
+<html lang="{{ site.lang | default: "en-US" }}">
 {% include head.html %}
 <body>
 

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "just-the-docs"
-  spec.version       = "0.2.3"
+  spec.version       = "0.2.4"
   spec.authors       = ["Patrick Marsceill"]
   spec.email         = ["patrick.marsceill@gmail.com"]
 

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'just-the-docs'
 
   spec.add_runtime_dependency "jekyll", "~> 3.8.5"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", "~> 12.3.1"
 
   spec.add_development_dependency "bundler", "~> 2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-the-docs",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A modern Jekyll theme for documentation",
   "repository": "pmarsceill/just-the-docs",
   "license": "MIT",


### PR DESCRIPTION
- [x] Added SEO feature that includs in all github-pages themes for seo optimization
- [x] Added `lang` as parameter in `_config.yml` to change `lang` attribute value in html tag

## Without SEO
![screen shot 2019-02-28 at 8 31 00 am](https://user-images.githubusercontent.com/13422799/53545766-3b8d5600-3b33-11e9-9c96-8f66e402b7c6.png)

## With SEO
![screen shot 2019-02-28 at 8 30 26 am](https://user-images.githubusercontent.com/13422799/53545771-3fb97380-3b33-11e9-9070-5ffbe8644dd6.png)
