### PR TITLE
Import custom Sass variable overrides before default variables are defined

### DIFF
--- a/assets/css/just-the-docs.scss
+++ b/assets/css/just-the-docs.scss
@@ -17,6 +17,12 @@
 @import "./support/support";
 
 //
+// Import custom overrides
+//
+
+@import "./custom/custom";
+
+//
 // Import custom color scheme scss
 //
 
@@ -36,8 +42,3 @@
 @import "./tables";
 @import "./code";
 @import "./utilities/utilities";
-
-//
-// Import custom overrides
-//
-@import "./custom/custom";


### PR DESCRIPTION
Addresses #50 

To override Sass variables defined with the `!default` flag, the [overrides must be imported before the default variables are defined](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_default).

This fixes the issue described in #50. However, it also means that any code besides variables in a user's existing `custom/custom.scss` file might no longer work properly due to its earlier position in the cascade. To solve that, I would propose the creation of a new file for custom code in addition to the existing `custom/custom.scss` file intended for variables, but that seems like a bigger workflow change.

Props to @ptvandi for suggesting this fix.