### PR TITLE
Add `nav_no_fold` to prevent navbar to fold child

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,7 +4,7 @@
     {% for node in pages_list %}
       {% unless node.nav_exclude %}
         {% if node.parent == nil %}
-          <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+          <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title or node.nav_no_fold %} active{% endif %}">
             {% if page.parent == node.title or page.grand_parent == node.title %}
               {% assign first_level_url = node.url | absolute_url %}
             {% endif %}


### PR DESCRIPTION
Adds a new front matter attribute `nav_no_fold` that when set to `true` on a *parent* page forces the navigation panel to display child at all time.

[See it live here](https://hippobaro.github.io/ultramarine/)