### PR TITLE
Fix duplicate generated title which produce invalid HTML5 structure

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,6 @@
   <meta name="Description" content="{{ page.description }}">
   {% endif %}
 
-  <title>{{ page.title }} - {{ site.title }}</title>
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | absolute_url }}">
 
   {% if site.ga_tracking != nil %}


### PR DESCRIPTION
Remove title tag as it's already generated by `jekyll-seo-tag` plugin