### PR TITLE
Fix jekyll highlight tag styles

### DIFF
--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -11,7 +11,8 @@ code {
   border-radius: $border-radius;
 }
 
-pre.highlight {
+pre.highlight,
+figure.highlight {
   padding: $sp-3;
   margin-bottom: 0;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Missing styles for the output of Jekyll's `highlight` tag which renders `figure`.

### Before

![image](https://user-images.githubusercontent.com/896475/58526580-607a7f00-819d-11e9-8496-d772087a0a19.png)

### After

![image](https://user-images.githubusercontent.com/896475/58526587-696b5080-819d-11e9-8e88-935e52d0c346.png)

Fixes #136