### PR TITLE
Fixing some Rouge styles for better JavaScript readability

### DIFF
--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -61,7 +61,7 @@ pre.highlight {
 .highlight .ld { color: #93a1a1; } // literal.date //
 .highlight .m { color: #2aa198; } // literal.number //
 .highlight .s { color: #2aa198; } // literal.string //
-.highlight .na { color: #93a1a1; } // name.attribute //
+.highlight .na { color: #555; } // name.attribute //
 .highlight .nb { color: #b58900; } // name.builtin //
 .highlight .nc { color: #268bd2; } // name.class //
 .highlight .no { color: #cb4b16; } // name.constant //
@@ -69,7 +69,7 @@ pre.highlight {
 .highlight .ni { color: #cb4b16; } // name.entity //
 .highlight .ne { color: #cb4b16; } // name.exception //
 .highlight .nf { color: #268bd2; } // name.function //
-.highlight .nl { color: #93a1a1; } // name.label //
+.highlight .nl { color: #555; } // name.label //
 .highlight .nn { color: #93a1a1; } // name.namespace //
 .highlight .nx { color: #555; } // name.other //
 .highlight .py { color: #93a1a1; } // name.property //


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1086030/59954214-6d0a9400-9438-11e9-932a-c344978b5865.png)

After:
![image](https://user-images.githubusercontent.com/1086030/59954224-86134500-9438-11e9-993c-2ed68f0006b9.png)
