### PR TITLE
Optimise generated navigation links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,32 +1,44 @@
-
-        <nav role="navigation" aria-label="Main navigation">
-          {% assign pages_list = site.html_pages | sort:"nav_order" %}
-          <ul class="navigation-list">
-            {% for node in pages_list %}{% unless node.nav_exclude %}{% if node.parent == nil %}
-            <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
-              {% if page.parent == node.title or page.grand_parent == node.title %}{% assign first_level_url = node.url | absolute_url %}{% endif %}
-              <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
-              {% if node.has_children %}{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}{% assign children_list = site.html_pages | sort:"nav_order" %}
+<nav role="navigation" aria-label="Main navigation">
+  <ul class="navigation-list">
+    {% assign pages_list = site.html_pages | sort:"nav_order" %}
+    {% for node in pages_list %}
+      {% unless node.nav_exclude %}
+        {% if node.parent == nil %}
+          <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+            {% if page.parent == node.title or page.grand_parent == node.title %}
+              {% assign first_level_url = node.url | absolute_url %}
+            {% endif %}
+            <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+            {% if node.has_children %}
+              {% assign children_list = site.html_pages | sort:"nav_order" %}
               <ul class="navigation-list-child-list ">
-                {% for child in children_list %}{% if child.parent == node.title %}
-                <li class="navigation-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
-                  {% if page.url == child.url or page.parent == child.title %}{% assign second_level_url = child.url | absolute_url %}{% endif %}
-                  <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
-                  {% if child.has_children %}{% if page.url == child.url or page.parent == child.title %}{% assign grand_children_list = site.html_pages | sort:"nav_order" %}
-                  <ul class="navigation-list-child-list">
-                    {% for grand_child in grand_children_list %}{% if grand_child.parent == child.title %}
-                    <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                      <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                {% for child in children_list %}
+                  {% if child.parent == node.title %}
+                    <li class="navigation-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+                      {% if page.url == child.url or page.parent == child.title %}
+                        {% assign second_level_url = child.url | absolute_url %}
+                      {% endif %}
+                      <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+                      {% if child.has_children %}
+                        {% assign grand_children_list = site.html_pages | sort:"nav_order" %}
+                        <ul class="navigation-list-child-list">
+                          {% for grand_child in grand_children_list %}
+                            {% if grand_child.parent == child.title %}
+                              <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
+                                <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                              </li>
+                            {% endif %}
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
                     </li>
-                    {% endif %}{% endfor %}
-                  </ul>
-                  {% endif %}{% endif %}
-                </li>
-                {% endif %}{% endfor %}
+                  {% endif %}
+                {% endfor %}
               </ul>
-              {% endif %}{% endif %}
-            </li>
-            {% endif %}{% endunless %}{% endfor %}
-          </ul>
-          
-        </nav>
+            {% endif %}
+          </li>
+        {% endif %}
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,44 +1,32 @@
-<nav role="navigation" aria-label="Main navigation">
-  <ul class="navigation-list">
-    {% assign pages_list = site.html_pages | sort:"nav_order" %}
-    {% for node in pages_list %}
-      {% unless node.nav_exclude %}
-        {% if node.parent == nil %}
-          <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
-            {% if page.parent == node.title or page.grand_parent == node.title %}
-              {% assign first_level_url = node.url | absolute_url %}
-            {% endif %}
-            <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
-            {% if node.has_children %}
-              {% assign children_list = site.html_pages | sort:"nav_order" %}
+
+        <nav role="navigation" aria-label="Main navigation">
+          {% assign pages_list = site.html_pages | sort:"nav_order" %}
+          <ul class="navigation-list">
+            {% for node in pages_list %}{% unless node.nav_exclude %}{% if node.parent == nil %}
+            <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+              {% if page.parent == node.title or page.grand_parent == node.title %}{% assign first_level_url = node.url | absolute_url %}{% endif %}
+              <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+              {% if node.has_children %}{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}{% assign children_list = site.html_pages | sort:"nav_order" %}
               <ul class="navigation-list-child-list ">
-                {% for child in children_list %}
-                  {% if child.parent == node.title %}
-                    <li class="navigation-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
-                      {% if page.url == child.url or page.parent == child.title %}
-                        {% assign second_level_url = child.url | absolute_url %}
-                      {% endif %}
-                      <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
-                      {% if child.has_children %}
-                        {% assign grand_children_list = site.html_pages | sort:"nav_order" %}
-                        <ul class="navigation-list-child-list">
-                          {% for grand_child in grand_children_list %}
-                            {% if grand_child.parent == child.title %}
-                              <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                                <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
-                              </li>
-                            {% endif %}
-                          {% endfor %}
-                        </ul>
-                      {% endif %}
+                {% for child in children_list %}{% if child.parent == node.title %}
+                <li class="navigation-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+                  {% if page.url == child.url or page.parent == child.title %}{% assign second_level_url = child.url | absolute_url %}{% endif %}
+                  <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+                  {% if child.has_children %}{% if page.url == child.url or page.parent == child.title %}{% assign grand_children_list = site.html_pages | sort:"nav_order" %}
+                  <ul class="navigation-list-child-list">
+                    {% for grand_child in grand_children_list %}{% if grand_child.parent == child.title %}
+                    <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
+                      <a href="{{ grand_child.url | absolute_url }}" class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
                     </li>
-                  {% endif %}
-                {% endfor %}
+                    {% endif %}{% endfor %}
+                  </ul>
+                  {% endif %}{% endif %}
+                </li>
+                {% endif %}{% endfor %}
               </ul>
-            {% endif %}
-          </li>
-        {% endif %}
-      {% endunless %}
-    {% endfor %}
-  </ul>
-</nav>
+              {% endif %}{% endif %}
+            </li>
+            {% endif %}{% endunless %}{% endfor %}
+          </ul>
+          
+        </nav>


### PR DESCRIPTION
This eliminates generation of inactive child links and multiple blank lines.

Clicking on a grandparent still displays all children and grandchildren;
delaying the display of grandchildren until their parent is active is deferred to a subsequent update.