### PR TITLE
Search config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 _site
 Gemfile.lock
 node_modules
-.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -27,9 +27,6 @@ search_enabled: true
 # Enable or disable heading anchors
 heading_anchors: true
 
-# Restrict display of grandchildren to selected parent when true:
-grandchildren_branch: false
-
 # Aux links for the upper right navigation
 aux_links:
   "Just the Docs on GitHub":

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,9 @@ search_enabled: true
 # Enable or disable heading anchors
 heading_anchors: true
 
+# Restrict display of grandchildren to selected parent when true:
+grandchildren_branch: false
+
 # Aux links for the upper right navigation
 aux_links:
   "Just the Docs on GitHub":

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,11 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 # Enable or disable the site search
 search_enabled: true
 
+# Set the search token separator
+search_tokenizer_separator: /[\s\-/]+/
+# For hyphenated-word search:
+# search_tokenizer_separator: /[\s/]+/
+
 # Enable or disable heading anchors
 heading_anchors: true
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,7 +20,6 @@
                     {%- endif -%}
                     <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
                     {%- if child.has_children -%}
-                    {%- if page.url == child.url or page.parent == child.title or site.grandchildren_branch != true -%}
                         {%- assign grand_children_list = site.html_pages | where: "parent", child.title | sort:"nav_order" -%}
                         <ul class="navigation-list-child-list">
                         {%- for grand_child in grand_children_list -%}
@@ -29,7 +28,6 @@
                           </li>
                         {%- endfor -%}
                       </ul>
-                    {%- endif -%}
                     {%- endif -%}
                   </li>
                 {%- endfor -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,7 +10,6 @@
             {%- endif -%}
             <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
             {%- if node.has_children -%}
-            {%- if page.url == node.url or page.parent == node.title or page.grand_parent == node.title -%}
               {%- assign children_list = site.html_pages | where: "parent", node.title | sort:"nav_order" -%}
               <ul class="navigation-list-child-list ">
                 {%- for child in children_list -%}
@@ -32,7 +31,6 @@
                   </li>
                 {%- endfor -%}
               </ul>
-            {%- endif -%}
             {%- endif -%}
           </li>
         {%- endif -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,7 +10,6 @@
             {%- endif -%}
             <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
             {%- if node.has_children -%}
-            {%- if page.url == node.url or page.parent == node.title or page.grand_parent == node.title -%}
               {%- assign children_list = site.html_pages | where: "parent", node.title | sort:"nav_order" -%}
               <ul class="navigation-list-child-list ">
                 {%- for child in children_list -%}
@@ -34,7 +33,6 @@
                   </li>
                 {%- endfor -%}
               </ul>
-            {%- endif -%}
             {%- endif -%}
           </li>
         {%- endif -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,7 +20,6 @@
                     {%- endif -%}
                     <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
                     {%- if child.has_children -%}
-                    {%- if page.url == child.url or page.parent == child.title -%}
                         {%- assign grand_children_list = site.html_pages | where: "parent", child.title | sort:"nav_order" -%}
                         <ul class="navigation-list-child-list">
                         {%- for grand_child in grand_children_list -%}
@@ -29,7 +28,6 @@
                           </li>
                         {%- endfor -%}
                       </ul>
-                    {%- endif -%}
                     {%- endif -%}
                   </li>
                 {%- endfor -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,6 +10,7 @@
             {%- endif -%}
             <a href="{{ node.url | absolute_url }}" class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
             {%- if node.has_children -%}
+            {%- if page.url == node.url or page.parent == node.title or page.grand_parent == node.title -%}
               {%- assign children_list = site.html_pages | where: "parent", node.title | sort:"nav_order" -%}
               <ul class="navigation-list-child-list ">
                 {%- for child in children_list -%}
@@ -33,6 +34,7 @@
                   </li>
                 {%- endfor -%}
               </ul>
+            {%- endif -%}
             {%- endif -%}
           </li>
         {%- endif -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,6 +20,7 @@
                     {%- endif -%}
                     <a href="{{ child.url | absolute_url }}" class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
                     {%- if child.has_children -%}
+                    {%- if page.url == child.url or page.parent == child.title or site.grandchildren_branch != true -%}
                         {%- assign grand_children_list = site.html_pages | where: "parent", child.title | sort:"nav_order" -%}
                         <ul class="navigation-list-child-list">
                         {%- for grand_child in grand_children_list -%}
@@ -28,6 +29,7 @@
                           </li>
                         {%- endfor -%}
                       </ul>
+                    {%- endif -%}
                     {%- endif -%}
                   </li>
                 {%- endfor -%}

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -53,7 +53,7 @@ function initSearch() {
       // Success!
       var data = JSON.parse(request.responseText);
 
-      lunr.tokenizer.separator = /[\s\-/]+/
+      lunr.tokenizer.separator = {{ site.search_tokenizer_separator }}
       var index = lunr(function () {
         this.ref('id');
         this.field('title', { boost: 200 });

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -52,8 +52,13 @@ function initSearch() {
     if (request.status >= 200 && request.status < 400) {
       // Success!
       var data = JSON.parse(request.responseText);
-
+      
+      {% if site.search_tokenizer_separator != nil %}
       lunr.tokenizer.separator = {{ site.search_tokenizer_separator }}
+      {% else %}
+      lunr.tokenizer.separator = /[\s\-/]+/
+      {% end %}
+      
       var index = lunr(function () {
         this.ref('id');
         this.field('title', { boost: 200 });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,10 @@ View this site's [_config.yml](https://github.com/pmarsceill/just-the-docs/tree/
 # Enable or disable the site search
 # Support true (default) or false
 search_enabled: true
+
+# Enable support for hyphenated search words:
+search_tokenizer_separator: /[\s/]+/
+
 ```
 
 ## Aux links

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -191,20 +191,6 @@ This would create the following navigation structure:
 +-- ..
 ```
 
-The current default is that when a grandparent is selected, the links to its
-children *and all its grandchildren* are displayed in the navigation menu.
-So in the above example, selecting `UI Components` displays the link to
-`Button Child Page` as well as the link to `Buttons`.
-
-Setting the following global option in `_config.yml` delays the display of links
-to grandchildren until their parent is selected. So selecting `UI Components`
-displays only the link to `Buttons`, and the link to `Button Child Page` is
-displayed when `Buttons` is selected.
-
-```
-grandchildren_branch: true
-```
-
 ---
 
 ## Auxiliary Navigation

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -191,6 +191,20 @@ This would create the following navigation structure:
 +-- ..
 ```
 
+The current default is that when a grandparent is selected, the links to its
+children *and all its grandchildren* are displayed in the navigation menu.
+So in the above example, selecting `UI Components` displays the link to
+`Button Child Page` as well as the link to `Buttons`.
+
+Setting the following global option in `_config.yml` delays the display of links
+to grandchildren until their parent is selected. So selecting `UI Components`
+displays only the link to `Buttons`, and the link to `Button Child Page` is
+displayed when `Buttons` is selected.
+
+```
+grandchildren_branch: true
+```
+
 ---
 
 ## Auxiliary Navigation

--- a/docs/search.md
+++ b/docs/search.md
@@ -59,6 +59,15 @@ In your site's `_config.yml`, enable search:
 search_enabled: true
 ```
 
+The default is for hyphens to separate tokens in search terms:
+`gem-based` is equivalent to `gem based`, matching either word.
+To allow search for hyphenated words:
+
+```yaml
+# Set the search token separator
+search_tokenizer_separator: /[\s/]+/
+```
+
 ## Hiding pages from search
 
 Sometimes you might have a page that you don't want to be indexed for the search nor to show up in search results, e.g, a 404 page. To exclude a page from search, add the `search_exclude: true` parameter to the page's YAML front matter:


### PR DESCRIPTION
(My previous PR #188 was made from my master fork, which was a mistake. For this one, I've made a topic branch in which I've reverted the previous commits.)

See #194 for the related enhancement request. This PR simply adds a config option `search_tokenizer_separator` which can be adjusted to support search for hyphenated words. (It does not enable the use of `+` and `-` in search terms.)

To test:
- search for `gem-based`, which matches both `gem` and `based`;
- set `search_tokenizer_separator: /[\s/]+/` in `_config.yml`;
- after restarting Jekyll, search for `gem-based`, which matches exactly that word.