### PR TITLE
Allow for custom overrides by the user

### DIFF
--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -1,0 +1,3 @@
+//
+// Custom overrides from a user.
+//

--- a/assets/css/just-the-docs.scss
+++ b/assets/css/just-the-docs.scss
@@ -42,3 +42,4 @@
 @import "./tables";
 @import "./code";
 @import "./utilities/utilities";
+@import "./overrides";

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -69,3 +69,20 @@ $link-color: $blue-000;
 ```
 
 _Note:_ Editing the variables directly in `_sass/support/variables.scss` is not recommended and can cause other dependencies to fail.
+
+## Override styles
+
+To add your own CSS at the end of the cascade, edit `_sass/overrides.scss` to add in your own custom CSS. This will allow for all overrides to be kept in a single file, and allow for any upstream changes to still be allowed.
+
+For example, if you'd like to add your own styles for printing a page, you could add the following styles.
+
+#### Example
+{: .no_toc }
+
+```scss
+// Print-only styles.
+@media print {
+  .side-bar, .page-header { display: none; }
+  .main-content { max-width: auto; margin: 1em;}
+}
+```


### PR DESCRIPTION
Howdy! 

I _just_ started using this, and it is phenomenal. Precisely what I needed to maintain some notes I've been working on— THANK YOU. 

And now... the PR. 

I've been wanting to customize some small pieces, add in some new styling/pieces on pages, etc. Overriding some templates locally is direct, but styles is less so. I started with the `_sass/custom/custom.scss` but that is set to create styles at the start of the cascade. For new styles, or overrides of say print styles— we'd want them at the very end. So, I added a blank file in here called `overrides.scss` that a user can utilize to add their own styles at the end. 

I added some info to the docs, and I will share with you the private repo where I am using this to show more practical examples. (Sorry, but it is currently a private repo— so only @pmarsceill will be able to see it). 

Thank you! 