### PR TITLE
feat: adds "edit this page" and "page last modified" to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,16 +38,20 @@ aux_links:
   "Just the Docs on GitHub":
     - "//github.com/pmarsceill/just-the-docs"
 
-# Footer content appears at the bottom of every page's main content
+# Footer content 
+# appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
-# Footer metadata
+
+# Footer last edited timestamp
 show_last_edit_time: true # show (default) or hide edit time
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
-show_gh_edit_link: true # show (default) or hide edit this page link
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_link: true # show or hide edit this page link
+gh_edit_link_text: "Edit this page on GitHub."
 gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
 gh_edit_branch: "master" # the branch that your docs is served from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
-edit_link_text: "Edit this page on GitHub."
 
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: nil

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ aux_links:
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 
 # Footer last edited timestamp
-last_edit_timestamp: true # show or hide edit time - page must have `last_modified` defined in the frontmatter
+last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
 
 # Footer "Edit this page on GitHub" link text

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,12 @@ aux_links:
 
 # Footer content appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
+# Footer metadata
+show_last_edit_time: true
+last_edit_time_format: "%b %e %Y at %I:%M %p"
+show_gh_edit_link: true
+gh_edit_repository: "https://github.com/pmarsceill/just-the-docs"
+edit_link_text: "Edit this page on GitHub"
 
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: nil

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ aux_links:
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 
 # Footer last edited timestamp
-show_last_edit_time: true # show (default) or hide edit time
+last_edit_timestamp: true # show or hide edit time - page must have `last_modified` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
 
 # Footer "Edit this page on GitHub" link text

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ show_last_edit_time: true
 last_edit_time_format: "%b %e %Y at %I:%M %p"
 show_gh_edit_link: true
 gh_edit_repository: "https://github.com/pmarsceill/just-the-docs"
-edit_link_text: "Edit this page on GitHub"
+edit_link_text: "Edit this page on GitHub."
 
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: nil

--- a/_config.yml
+++ b/_config.yml
@@ -42,9 +42,11 @@ aux_links:
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 # Footer metadata
 show_last_edit_time: true
-last_edit_time_format: "%b %e %Y at %I:%M %p"
+last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
 show_gh_edit_link: true
-gh_edit_repository: "https://github.com/pmarsceill/just-the-docs"
+gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
+gh_edit_branch: "master" # switch to the branch that your docs is served from
+gh_edit_view_mode: "tree" # switch to "edit" if you want the user to jump into the editor immediately
 edit_link_text: "Edit this page on GitHub."
 
 # Color scheme currently only supports "dark" or nil (default)

--- a/_config.yml
+++ b/_config.yml
@@ -41,12 +41,12 @@ aux_links:
 # Footer content appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 # Footer metadata
-show_last_edit_time: true
+show_last_edit_time: true # show (default) or hide edit time
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
-show_gh_edit_link: true
+show_gh_edit_link: true # show (default) or hide edit this page link
 gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
-gh_edit_branch: "master" # switch to the branch that your docs is served from
-gh_edit_view_mode: "tree" # switch to "edit" if you want the user to jump into the editor immediately
+gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 edit_link_text: "Edit this page on GitHub."
 
 # Color scheme currently only supports "dark" or nil (default)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,6 +59,9 @@ layout: table_wrappers
             {% endif %}
           {% endunless %}
           <div id="main-content" class="page-content" role="main">
+            {% if page.last_modified_date %}
+            <p class="text-small text-grey-dk-000 mb-0">Page last modified: {{ page.last_modified_date | date: "%Y-%m-%d %H:%M" }}</p>
+            {% endif %}
             {% if site.heading_anchors != false %}
               {% include vendor/anchor_headings.html html=content  beforeHeading = "true" anchorBody="<svg class=\"d-inline-block v-align-middle\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"18\" height=\"18\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\"></path></svg>" anchorClass="anchor-heading" %}
             {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -86,7 +86,7 @@ layout: table_wrappers
             </ul>
           {% endif %}
 
-          {% if site.footer_content != nil %}
+          {% if site.footer_content != nil or site.show_last_edit_time or site.show_gh_edit_link %}
             <hr>
             <footer role="contentinfo">
               {% if site.show_last_edit_time and site.last_edit_time_format and page.last_modified_date %}
@@ -99,7 +99,9 @@ layout: table_wrappers
                 <a href="{{ site.gh_edit_repository }}/tree/master/{{ page.path }}">Edit this page on GitHub.</a>
               </p>
               {% endif %}
+              {% if site.footer_content != nil %}
               <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>
+              {% endif %}
             </footer>
           {% endif %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,6 +83,9 @@ layout: table_wrappers
           {% if site.footer_content != nil %}
             <hr>
             <footer role="contentinfo">
+              {% if page.last_modified_date %}
+              <p class="text-small text-grey-dk-000 mb-0">Page last modified: {{ page.last_modified_date | date: "%Y-%m-%d %H:%M" }}</p>
+              {% endif %}
               <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>
             </footer>
           {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,7 +89,7 @@ layout: table_wrappers
           {% if site.footer_content != nil or site.show_last_edit_time or site.show_gh_edit_link %}
             <hr>
             <footer role="contentinfo">
-              {% if site.show_last_edit_time and site.last_edit_time_format and page.last_modified_date %}
+              {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
               <p class="text-small text-grey-dk-000 mb-0">
                 Page last modified: {{ page.last_modified_date | date: site.last_edit_time_format }}.
               </p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,7 +96,7 @@ layout: table_wrappers
               {% endif %}
               {% if site.show_gh_edit_link and site.edit_link_text %}
               <p class="text-small text-grey-dk-000 mb-0">
-                <a href="{{ site.gh_edit_repository }}/tree/master/{{ page.path }}">Edit this page on GitHub.</a>
+                <a href="{{ site.gh_edit_repository }}/tree/master/{{ page.path }}">{{ site.edit_link_text }}</a>
               </p>
               {% endif %}
               {% if site.footer_content != nil %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,9 +59,6 @@ layout: table_wrappers
             {% endif %}
           {% endunless %}
           <div id="main-content" class="page-content" role="main">
-            {% if page.last_modified_date %}
-            <p class="text-small text-grey-dk-000 mb-0">Page last modified: {{ page.last_modified_date | date: "%Y-%m-%d %H:%M" }}</p>
-            {% endif %}
             {% if site.heading_anchors != false %}
               {% include vendor/anchor_headings.html html=content  beforeHeading = "true" anchorBody="<svg class=\"d-inline-block v-align-middle\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"18\" height=\"18\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\"></path></svg>" anchorClass="anchor-heading" %}
             {% else %}
@@ -86,8 +83,15 @@ layout: table_wrappers
           {% if site.footer_content != nil %}
             <hr>
             <footer role="contentinfo">
-              {% if page.last_modified_date %}
-              <p class="text-small text-grey-dk-000 mb-0">Page last modified: {{ page.last_modified_date | date: "%Y-%m-%d %H:%M" }}</p>
+              {% if site.show_last_edit_time and site.last_edit_time_format and page.last_modified_date %}
+              <p class="text-small text-grey-dk-000 mb-0">
+                Page last modified: {{ page.last_modified_date | date: site.last_edit_time_format }}.
+              </p>
+              {% endif %}
+              {% if site.show_gh_edit_link and site.edit_link_text %}
+              <p class="text-small text-grey-dk-000 mb-0">
+                <a href="{{ site.gh_edit_repository }}/tree/master/{{ page.path }}">Edit this page on GitHub.</a>
+              </p>
               {% endif %}
               <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>
             </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,9 +94,16 @@ layout: table_wrappers
                 Page last modified: {{ page.last_modified_date | date: site.last_edit_time_format }}.
               </p>
               {% endif %}
-              {% if site.show_gh_edit_link and site.edit_link_text %}
+              {% 
+                if 
+                  site.show_gh_edit_link and 
+                  site.edit_link_text and 
+                  site.gh_edit_repository and 
+                  site.gh_edit_view_mode and 
+                  site.gh_edit_branch
+              %}
               <p class="text-small text-grey-dk-000 mb-0">
-                <a href="{{ site.gh_edit_repository }}/tree/master/{{ page.path }}">{{ site.edit_link_text }}</a>
+                <a href="{{ site.gh_edit_repository }}/{{site.gh_edit_view_mode}}/{{site.gh_edit_branch}}/{{ page.path }}">{{ site.edit_link_text }}</a>
               </p>
               {% endif %}
               {% if site.footer_content != nil %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,8 +96,8 @@ layout: table_wrappers
               {% endif %}
               {% 
                 if 
-                  site.show_gh_edit_link and 
-                  site.edit_link_text and 
+                  site.gh_edit_link and 
+                  site.gh_edit_link_text and 
                   site.gh_edit_repository and 
                   site.gh_edit_view_mode and 
                   site.gh_edit_branch

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,17 @@ heading_anchors: true
 ```yaml
 # Footer content appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
+# Footer metadata
+show_last_edit_time: true
+last_edit_time_format: "%b %e %Y at %I:%M %p"
+show_gh_edit_link: true
+gh_edit_repository: "https://github.com/pmarsceill/just-the-docs"
+edit_link_text: "Edit this page on GitHub"
 ```
+
+* the "page last modified" data will only display if a page has a key called `last_modified_date`, formatted in some readable date format
+* `last_edit_time_format` uses Ruby's DateTime formatter; see examples and more information [at this link.](https://apidock.com/ruby/DateTime/strftime)
+* `gh_edit_repository` should be changed to the project's GitHub repository
 
 ## Color scheme
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ heading_anchors: true
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 
 # Footer last edited timestamp
-last_edit_timestamp: true # show (default) or hide edit time
+last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
 
 # Footer "Edit this page on GitHub" link text

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,23 +63,27 @@ heading_anchors: true
 ## Footer content
 
 ```yaml
-# Footer content appears at the bottom of every page's main content
+# Footer content 
+# appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
-# Footer metadata
-show_last_edit_time: true
-last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format
-show_gh_edit_link: true
+
+# Footer last edited timestamp
+last_edit_timestamp: true # show (default) or hide edit time
+last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_link: true # show or hide edit this page link
+gh_edit_link_text: "Edit this page on GitHub."
 gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
-gh_edit_branch: "master" # switch to the branch that your docs is served from
-gh_edit_view_mode: "tree" # switch to "edit" if you want the user to jump into the editor immediately
-edit_link_text: "Edit this page on GitHub."
+gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 ```
 
-* the "page last modified" data will only display if a page has a key called `last_modified_date`, formatted in some readable date format
-* `last_edit_time_format` uses Ruby's DateTime formatter; see examples and more information [at this link.](https://apidock.com/ruby/DateTime/strftime)
-* `gh_edit_repository` is the URL of the project's GitHub repository
-* `gh_edit_branch` is the branch that the docs site is served from; defaults to `master`
-* `gh_edit_view_mode` is `"tree"` by default, which brings the user to the github page; switch to `"edit"` to bring the user directly into editing mode
+- the "page last modified" data will only display if a page has a key called `last_modified_date`, formatted in some readable date format
+- `last_edit_time_format` uses Ruby's DateTime formatter; see examples and more information [at this link.](https://apidock.com/ruby/DateTime/strftime)
+- `gh_edit_repository` is the URL of the project's GitHub repository
+- `gh_edit_branch` is the branch that the docs site is served from; defaults to `master`
+- `gh_edit_view_mode` is `"tree"` by default, which brings the user to the github page; switch to `"edit"` to bring the user directly into editing mode
 
 ## Color scheme
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,15 +67,19 @@ heading_anchors: true
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 # Footer metadata
 show_last_edit_time: true
-last_edit_time_format: "%b %e %Y at %I:%M %p"
+last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format
 show_gh_edit_link: true
-gh_edit_repository: "https://github.com/pmarsceill/just-the-docs"
-edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
+gh_edit_branch: "master" # switch to the branch that your docs is served from
+gh_edit_view_mode: "tree" # switch to "edit" if you want the user to jump into the editor immediately
+edit_link_text: "Edit this page on GitHub."
 ```
 
 * the "page last modified" data will only display if a page has a key called `last_modified_date`, formatted in some readable date format
 * `last_edit_time_format` uses Ruby's DateTime formatter; see examples and more information [at this link.](https://apidock.com/ruby/DateTime/strftime)
-* `gh_edit_repository` should be changed to the project's GitHub repository
+* `gh_edit_repository` is the URL of the project's GitHub repository
+* `gh_edit_branch` is the branch that the docs site is served from; defaults to `master`
+* `gh_edit_view_mode` is `"tree"` by default, which brings the user to the github page; switch to `"edit"` to bring the user directly into editing mode
 
 ## Color scheme
 


### PR DESCRIPTION
Hey there, this PR implements the feature requested in #166 (adding a hard-coded page last modified to the footer), and additionally adds an "edit this page" link at the footer. As requested in the PR chain, I've also added variables that change the target branch of the repository, and the edit mode of the link.

All of these features can be toggled on/off in `_config.yml`, and I've added appropriate documentation explaining how to use it.

In addition, I've made the display of the footer just depend on one of the footer features being available (footer content, last modified, or GitHub page edit link).

Here's a screenshot of what the footer looks like:

![footer](https://i.imgur.com/zK633x1.png)

This is my first time contributing, to the project, so let me know if there's anything else I should change before merging!