### PR TITLE
Don't override image's height

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -99,7 +99,6 @@ li {
 
 img {
   max-width: 100%;
-  height: auto;
 }
 
 hr {


### PR DESCRIPTION
By specifying a height in the css, we are no longer able to specify the image's height on the element. E.g.:

    Here is an inline ![smiley](smiley.png){:height="36px" width="36px"}.