### PR TITLE
Update jekyll requirement from 3.8 to 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 .bundle
 .sass-cache
+.jekyll-cache
 _site
 Gemfile.lock
 node_modules

--- a/404.html
+++ b/404.html
@@ -8,4 +8,4 @@ search_exclude: true
 
 <h1>Page not found</h1>
 
-<p>The page you requested could not be found. Try using the navigation {% if site.search_enabled %}or search {% endif %}to find what you're looking for or go to this <a href="{{ site.url }}{{ site.baseurl }}">site's home page</a>.</p>
+<p>The page you requested could not be found. Try using the navigation {% if site.search_enabled %}or search {% endif %}to find what you're looking for or go to this <a href="{{ site.url }}{{ site.baseurl }}/">site's home page</a>.</p>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Your theme is set up just like a normal Jekyll site! To test your theme, run `bu
 
 When the theme is released, only the files in `_layouts`, `_includes`, and `_sass` tracked with Git will be released.
 
+## Upgrade your links (Jekyll 4+)
+
+Since Jekyll 4+ the tags `link` and `post_url` include the relative_url. You should no longer prepend `{{ site.baseurl }}` to them.
+
+For further details: 
+- https://github.com/jekyll/jekyll/pull/6727
+- https://github.com/jekyll/jekyll/pull/7589
+
 ## License
 
 The theme is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@ layout: table_wrappers
   <div class="page-wrap">
     <div class="side-bar">
       <div class="site-header">
-        <a href="{{ site.url }}{{ site.baseurl }}" class="site-title lh-tight">{% include title.html %}</a>
+        <a href="{{ site.url }}{{ site.baseurl }}/" class="site-title lh-tight">{% include title.html %}</a>
         <button class="menu-button fs-3 js-main-nav-trigger" data-text-toggle="Hide" type="button">Menu</button>
       </div>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ color_scheme: "dark"
 
 <script type="text/javascript" src="{{ "/assets/js/dark-mode-preview.js" | absolute_url }}"></script>
 
-See [Customization]({{ site.baseurl }}{% link docs/customization.md %}) for more information.
+See [Customization]({% link docs/customization.md %}) for more information.
 
 ## Google Analytics
 

--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -192,7 +192,7 @@ This would create the following navigation structure:
 
 ## Auxiliary Navigation
 
-To add a auxiliary navigation item to your site (in the upper right on all pages), add it to the `aux_nav` [configuration option]({{ site.baseurl }}{% link docs/configuration.md %}#aux-nav) in your site's `_config.yml` file.
+To add a auxiliary navigation item to your site (in the upper right on all pages), add it to the `aux_nav` [configuration option]({% link docs/configuration.md %}#aux-nav) in your site's `_config.yml` file.
 
 #### Example
 {: .no_toc }

--- a/docs/ui-components/buttons.md
+++ b/docs/ui-components/buttons.md
@@ -56,7 +56,7 @@ GitHub Flavored Markdown does not support the `button` element, so you'll have t
 
 ### Button size
 
-Wrap the button in a container that uses the [font-size utility classes]({{ site.baseurl }}{% link docs/utilities/typography.md %}) to scale buttons:
+Wrap the button in a container that uses the [font-size utility classes]({% link docs/utilities/typography.md %}) to scale buttons:
 
 <div class="code-example" markdown="1">
 <span class="fs-6">
@@ -79,7 +79,7 @@ Wrap the button in a container that uses the [font-size utility classes]({{ site
 
 ### Spacing between buttons
 
-Use the [margin utility classes]({{ site.baseurl }}{% link docs/utilities/layout.md %}#spacing) to add spacing between two buttons in the same block.
+Use the [margin utility classes]({% link docs/utilities/layout.md %}#spacing) to add spacing between two buttons in the same block.
 
 <div class="code-example" markdown="1">
 [Button with space](http://example.com/){: .btn .btn-purple .mr-2 }

--- a/docs/ui-components/typography.md
+++ b/docs/ui-components/typography.md
@@ -111,4 +111,4 @@ Text can be **bold**, _italic_, or ~~strikethrough~~.
 
 There are a number of specific typographic CSS classes that allow you to override default styling for font size, font weight, line height, and capitalization.
 
-[View typography utilities]({{ site.baseurl }}{% link docs/utilities/utilities.md %}#typography){: .btn .btn-outline }
+[View typography utilities]({% link docs/utilities/utilities.md %}#typography){: .btn .btn-outline }

--- a/index.md
+++ b/index.md
@@ -62,7 +62,7 @@ If you're hosting your site on GitHub Pages, [set up GitHub Pages and Jekyll loc
 
 ### Configure Just the Docs
 
-- [See configuration options]({{ site.baseurl }}{% link docs/configuration.md %})
+- [See configuration options]({% link docs/configuration.md %})
 
 ---
 

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "just-the-docs"
-  spec.version       = "0.2.7"
+  spec.version       = "0.3.0"
   spec.authors       = ["Patrick Marsceill"]
   spec.email         = ["patrick.marsceill@gmail.com"]
 
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8.5"
+  spec.add_runtime_dependency "jekyll", "~> 4.0.0"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", "~> 12.3.1"
 


### PR DESCRIPTION
Upgrading to jekyll 4.0 means updating your links. See https://github.com/pmarsceill/just-the-docs/pull/197