### PR TITLE
Enable "footer_links" configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,12 @@ aux_links:
 
 # Footer content appears at the bottom of every page's main content
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
+# footer links for the page bottom navigation
+footer_links:
+  "Just the Docs on GitHub":
+    - "//github.com/pmarsceill/just-the-docs"
+  "Just the Docs on GitHub":
+    - "//github.com/pmarsceill/just-the-docs"
 
 # Color scheme currently only supports "dark" or nil (default)
 color_scheme: nil

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', "{{ site.ga_tracking }}");
+      gtag('config', '{{ site.ga_tracking }}', { 'anonymize_ip': true });
     </script>
 
   {% endif %}

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex" />

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,2 @@
 <meta name="robots" content="noindex" />
+<meta property="og:type" content="wiki">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,7 +93,7 @@ layout: table_wrappers
             <footer role="contentinfo">
               <ul class="list-style-none text-small aux-nav">
                 {% for link in site.footer_links %}
-                  <li class="d-inline-block my-0{% unless forloop.last %} mr-2{% endunless %}"><a href="{{ link.last }}">{{ link.first }}</a></li>
+                  <li class="d-inline-block my-0{% unless forloop.last %} mr-2{% endunless %}"><a href="{{ link.last }}" target="_blank">{{ link.first }}</a></li>
                 {% endfor %}
               </ul>
             </footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -97,6 +97,11 @@ layout: table_wrappers
                 {% endfor %}
               </ul>
             </footer>
+          {% elsif site.footer_content != nil %}
+            <hr>
+            <footer role="contentinfo">
+              <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>
+            </footer>
           {% endif %}
         </div>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@ layout: table_wrappers
         {% include nav.html %}
       </div>
       <footer class="site-footer">
-        <p class="text-small text-grey-dk-000 mb-4">This site uses <a href="https://github.com/pmarsceill/just-the-docs">Just the Docs</a>, a documentation theme for Jekyll.</p>
+        <p class="text-small text-grey-dk-000 mb-4">Copyright &copy; 2013 <a href="https://www.labs64.com">Labs64 GmbH</a></p>
       </footer>
     </div>
     <div class="main-content-wrap js-main-content" tabindex="0">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,9 +24,11 @@ layout: table_wrappers
       <div class="navigation main-nav js-main-nav">
         {% include nav.html %}
       </div>
+      {% if site.footer_content != nil %}
       <footer class="site-footer">
-        <p class="text-small text-grey-dk-000 mb-4">Copyright &copy; 2013 <a href="https://www.labs64.com">Labs64 GmbH</a></p>
+        <p class="text-small text-grey-dk-000 mb-4">{{ site.footer_content }}</a></p>
       </footer>
+      {% endif %}
     </div>
     <div class="main-content-wrap js-main-content" tabindex="0">
       <div class="main-content">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,13 +88,16 @@ layout: table_wrappers
             </ul>
           {% endif %}
 
-          {% if site.footer_content != nil %}
+          {% if site.footer_links != nil %}
             <hr>
             <footer role="contentinfo">
-              <p class="text-small text-grey-dk-000 mb-0">{{ site.footer_content }}</p>
+              <ul class="list-style-none text-small aux-nav">
+                {% for link in site.footer_links %}
+                  <li class="d-inline-block my-0{% unless forloop.last %} mr-2{% endunless %}"><a href="{{ link.last }}">{{ link.first }}</a></li>
+                {% endfor %}
+              </ul>
             </footer>
           {% endif %}
-
         </div>
       </div>
     </div>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -13,6 +13,9 @@
 //// Colors
 ////
 
+$labs64-main: #E14817;
+$labs64-link: #7B2A10;
+
 //$white: #fff;
 
 //$grey-dk-000: #959396;
@@ -61,7 +64,7 @@
 //$body-heading-color: $grey-dk-300;
 //$search-result-preview-color: $grey-dk-000;
 //$nav-child-link-color: $grey-dk-100;
-//$link-color: $purple-000;
+$link-color: $labs64-link;
 //$btn-primary-color: $purple-100;
 //$base-button-color: #f7f7f7;
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,17 @@ heading_anchors: true
 footer_content: "Copyright &copy; 2017-2019 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 ```
 
+## Footer links
+
+```yaml
+# Footer links appears at the bottom of every page's main content (overrides "footer_content" if defined)
+footer_links:
+  "Just the Docs on GitHub":
+    - "//github.com/pmarsceill/just-the-docs"
+  "Just the Docs on GitHub":
+    - "//github.com/pmarsceill/just-the-docs"
+```
+
 ## Color scheme
 
 ```yaml


### PR DESCRIPTION
Hello,

We are going to use this theme for _Labs64 NetLicensing Wiki_ and currently in the adoption phase.
Please find our enhancement which is allowing to replace "footer_content" the page footer by "footer_links" set.
This might be useful if somebody want's to expose set of the predefined links to be shown on every page.
Docs have been updated as well.