### PR TITLE
search-data.json: remove double quotes from titles

### DIFF
--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -3,7 +3,7 @@
 {
   {% assign comma = false %}
   {% for page in site.html_pages %}{% if page.search_exclude != true %}{% if comma == true%},{% endif %}"{{ forloop.index0 }}": {
-    "title": "{{ page.title | replace: '&amp;', '&' }}",
+    "title": "{{ page.title | replace: '&amp;', '&' | replace: '"', '\"' }}",
     "content": "{{ page.content | markdownify | replace: '</h', ' . </h' | replace: '<hr', ' . <hr' | replace: '</p', ' . </p' | replace: '</ul', ' . </ul' | replace: '</tr', ' . </tr' | replace: '</li', ' | </li' | replace: '</td', ' | </td' | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | replace: ' .  .  . ', ' . ' | replace: ' .  . ', ' . ' | normalize_whitespace }}",
     "url": "{{ page.url | absolute_url }}",
     "relUrl": "{{ page.url }}"

--- a/docs/search.md
+++ b/docs/search.md
@@ -39,7 +39,7 @@ This command creates the `search-data.json` file that Jekyll uses to create your
 {
   {% assign comma = false %}
   {% for page in site.html_pages %}{% if page.search_exclude != true %}{% if comma == true%},{% endif %}"{{ forloop.index0 }}": {
-    "title": "{{ page.title | replace: '&amp;', '&' }}",
+    "title": "{{ page.title | replace: '&amp;', '&' | replace: '"', '\"' }}",
     "content": "{{ page.content | markdownify | replace: '</h', ' . </h' | replace: '<hr', ' . <hr' | replace: '</p', ' . </p' | replace: '</ul', ' . </ul' | replace: '</tr', ' . </tr' | replace: '</li', ' | </li' | replace: '</td', ' | </td' | strip_html | escape_once | remove: 'Table of contents' | remove: '```'  | remove: '---' | replace: '\', ' ' | replace: ' .  .  . ', ' . ' | replace: ' .  . ', ' . ' | normalize_whitespace }}",
     "url": "{{ page.url | absolute_url }}",
     "relUrl": "{{ page.url }}"


### PR DESCRIPTION
If a page title contains double quotes, search-data.json produces invalid JSON (the double quotes aren't escaped).

This change replaces them with escaped quotes (`\"`), which results in valid JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmarsceill/just-the-docs/251)
<!-- Reviewable:end -->
