### PR TITLE
Fix duplicated title and description tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,13 +2,13 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-  {% if site.plugins.jekyll-seo == nil %}
+  {% unless site.plugins contains "jekyll-seo-tag" %}
     <title>{{ page.title }} - {{ site.title }}</title>
 
     {% if page.description %}
       <meta name="Description" content="{{ page.description }}">
     {% endif %}
-  {% endif %}
+  {% endunless %}
 
   <link rel="shortcut icon" href="{{ 'favicon.ico' | absolute_url }}" type="image/x-icon">
 


### PR DESCRIPTION
Currently just-the-docs renders two title and description tags
when used with jekyll-seo-tag. This patch fixes plugin detection
conditonal.