### PR TITLE
Fix site header link when url and baseurl are empty

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@ layout: table_wrappers
   <div class="page-wrap">
     <div class="side-bar">
       <div class="site-header">
-        <a href="{{ site.url }}{{ site.baseurl }}" class="site-title lh-tight">{% include title.html %}</a>
+        <a href="{{ site.url }}{{ site.baseurl }}/" class="site-title lh-tight">{% include title.html %}</a>
         <button class="menu-button fs-3 js-main-nav-trigger" data-text-toggle="Hide" type="button">Menu</button>
       </div>
 


### PR DESCRIPTION
When both `site.url` and `site.baseurl` are empty, the "logo" header link is `""` making it equivalent to `"."`. This PR fixes it by making it `"/"`.