### PR TITLE
Fix code-blocks scaling

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -86,7 +86,7 @@ a:not([class]) {
 
 code {
   font-family: $mono-font-family;
-  font-size: 12px;
+  font-size: 75%;
   line-height: $body-line-height;
 }
 

--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -4,7 +4,7 @@
 // stylelint-disable selector-no-qualifying-type, declaration-block-semicolon-newline-after,declaration-block-single-line-max-declarations, selector-no-type, selector-max-type
 
 code {
-  padding: 0.2em 0.15em;
+  padding: 0.25em 0.29em;
   font-weight: 400;
   background-color: $code-background-color;
   border: $border $border-color;


### PR DESCRIPTION
Fixes #346

So, I changed the size of code blocks from `12px` to `75%`, that means it will now scale with headers and don't maintain static size while looking exactly the same in normal text. I also changed padding because it looks slightly better while in the header.

**Working demo**
[My Docs](https://replacementbot.github.io/docs/configuration)
[Code](https://github.com/ReplacementBot/docs/blob/master/_sass/custom/custom.scss)