### PR TITLE
Remove collapsible TOC on nav doc

### DIFF
--- a/docs/navigation-structure.md
+++ b/docs/navigation-structure.md
@@ -7,14 +7,11 @@ nav_order: 5
 # Navigation Structure
 {: .no_toc }
 
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
+## Table of contents
+{: .no_toc .text-delta }
+
 1. TOC
 {:toc}
-</details>
 
 ---
 


### PR DESCRIPTION
Didn't release this was implemented on the page for testing -- removing it.

Docs update only.