### PR TITLE
Fixed css .search-active.main

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -308,6 +308,8 @@
   @include mq(md) {
     .main {
       position: fixed;
+      right: 0;
+      left: 0;
     }
   }
 


### PR DESCRIPTION
This is a small css fix.
If a page does not fill the whole width and the search is activated, the page width is decreased.
This happens for example with the following page:
```
---
layout: default
title: Test
---

# Test

This sentence does not fill the whole page width.
```