### PR TITLE
Improve accessibility by adding label to Anchor links.

### DIFF
--- a/_includes/vendor/anchor_headings.html
+++ b/_includes/vendor/anchor_headings.html
@@ -64,7 +64,7 @@
     {% capture anchor %}{% endcapture %}
 
     {% if html_id and headerLevel >= minHeader and headerLevel <= maxHeader %}
-      {% capture anchor %}href="#{{ html_id}}"{% endcapture %}
+      {% capture anchor %}href="#{{ html_id}}" aria-labelledby="{{ html_id}}"{% endcapture %}
 
       {% if include.anchorClass %}
         {% capture anchor %}{{ anchor }} class="{{ include.anchorClass }}"{% endcapture %}


### PR DESCRIPTION
I ran Lighthouse on just-the-docs and noticed the anchor links were missing a "discernible name".

This adds `aria-labelledby` to the link to improve these for screenreaders.

<img width="841" alt="CleanShot 2020-07-04 at 14 30 55@2x" src="https://user-images.githubusercontent.com/155044/86521271-5b0d5080-be03-11ea-9c58-148c0fe2e74e.png">

Test this locally, with LightHouse, and the change fixed it.