### PR TITLE
Adjust dl layout

### DIFF
--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -109,7 +109,7 @@
 
   dl {
     display: grid;
-    grid-template-columns: max-content 1fr;
+    grid-template: auto / 10em 1fr;
   }
 
   dt,
@@ -118,16 +118,18 @@
   }
 
   dt {
+    grid-column: 1;
     text-align: right;
-
+    font-weight: 500;
     &::after {
       content: ":";
     }
   }
 
   dd {
+    grid-column: 2;
     margin-left: 1em;
-    font-weight: 500;
+    margin-bottom: 0;
   }
 
   .anchor-heading {

--- a/_sass/content.scss
+++ b/_sass/content.scss
@@ -119,8 +119,8 @@
 
   dt {
     grid-column: 1;
-    text-align: right;
     font-weight: 500;
+    text-align: right;
     &::after {
       content: ":";
     }
@@ -128,8 +128,8 @@
 
   dd {
     grid-column: 2;
-    margin-left: 1em;
     margin-bottom: 0;
+    margin-left: 1em;
   }
 
   .anchor-heading {

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -140,6 +140,37 @@ end
 <dd>Green</dd>
 </dl>
 
+#### Multiple description terms and values
+
+Term
+: Brief description of Term
+
+Longer Term
+: Longer description of Term,
+  possibly more than one line
+
+Term
+: First description of Term,
+  possibly more than one line
+
+: Second description of Term,
+  possibly more than one line
+
+Term1
+Term2
+: Single description of Term1 and Term2,
+  possibly more than one line
+
+Term1
+Term2
+: First description of Term1 and Term2,
+  possibly more than one line
+
+: Second description of Term1 and Term2,
+  possibly more than one line
+  
+### More code
+
 ```
 Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
 ```


### PR DESCRIPTION
Works for description lists with multiple `dt` and `dd` elements.

<img width="566" alt="Screenshot 2020-08-03 at 17 32 43" src="https://user-images.githubusercontent.com/18308236/89200418-4a8df880-d5b0-11ea-82ec-d2d0fcd836aa.png">
