### PR TITLE
Inhibit text-transform for code in h4

### DIFF
--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -27,6 +27,10 @@ h4,
   letter-spacing: 0.1em;
 }
 
+h4 code {
+  text-transform: none;
+}
+
 h5,
 .text-epsilon {
   @include fs-3;

--- a/docs/index-test.md
+++ b/docs/index-test.md
@@ -39,7 +39,7 @@ GitHubPages::Dependencies.gems.each do |gem, version|
 end
 ```
 
-#### [](#header-4)Header 4
+#### [](#header-4)Header 4 `with code not transformed`
 
 *   This is an unordered list following a header.
 *   This is an unordered list following a header.


### PR DESCRIPTION
Code in headings should not be transformed to uppercase.

Tested in `index-test.md`

Fixes #403