### PR TITLE
Ensure pages with nav_exclude are ignored by navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Page not found
+title: 404
 permalink: /404
 nav_exclude: true
 search_exclude: true

--- a/_config.yml
+++ b/_config.yml
@@ -63,8 +63,8 @@ aux_links:
 aux_links_new_tab: false
 
 # Sort order for navigation links
-nav_sort: case_insensitive # default, equivalent to nil
-# nav_sort: case_sensitive # Capital letters sorted before lowercase
+# nav_sort: case_insensitive # default, equivalent to nil
+nav_sort: case_sensitive # Capital letters sorted before lowercase
 
 # Footer content
 # appears at the bottom of every page's main content

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,7 @@
 <ul class="nav-list">
-  {%- assign ordered_pages_list = site.html_pages | where_exp:"item", "item.nav_order != nil" -%}
-  {%- assign unordered_pages_list = site.html_pages | where_exp:"item", "item.nav_order == nil" -%}
+  {%- assign included_pages_list = site.html_pages | where_exp:"item", "item.nav_exclude != true" | where_exp:"item", "item.title != nil" -%}
+  {%- assign ordered_pages_list = included_pages_list | where_exp:"item", "item.nav_order != nil"  -%}
+  {%- assign unordered_pages_list = included_pages_list | where_exp:"item", "item.nav_order == nil" -%}
   {%- if site.nav_sort == 'case_insensitive' -%}
     {%- assign sorted_ordered_pages_list = ordered_pages_list | sort_natural:"nav_order" -%}
     {%- assign sorted_unordered_pages_list = unordered_pages_list | sort_natural:"title" -%}
@@ -10,8 +11,7 @@
   {%- endif -%}
   {%- assign pages_list = sorted_ordered_pages_list | concat: sorted_unordered_pages_list -%}
   {%- for node in pages_list -%}
-    {%- unless node.nav_exclude -%}
-      {%- if node.parent == nil and node.title -%}
+      {%- if node.parent == nil -%}
         <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
           {%- if page.parent == node.title or page.grand_parent == node.title -%}
             {%- assign first_level_url = node.url | absolute_url -%}
@@ -24,7 +24,6 @@
             {%- assign children_list = pages_list | where: "parent", node.title -%}
             <ul class="nav-list ">
             {%- for child in children_list -%}
-              {%- unless child.nav_exclude -%}
                 <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
                   {%- if page.url == child.url or page.parent == child.title -%}
                     {%- assign second_level_url = child.url | absolute_url -%}
@@ -44,12 +43,10 @@
                     </ul>
                   {%- endif -%}
                 </li>
-              {%- endunless -%}
             {%- endfor -%}
             </ul>
           {%- endif -%}
         </li>
       {%- endif -%}
-    {%- endunless -%}
   {%- endfor -%}
 </ul>

--- a/docs/untitled-test.md
+++ b/docs/untitled-test.md
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+# Untitled test page
+
+This page should not appear in the navigation.

--- a/docs/untitled-test.md
+++ b/docs/untitled-test.md
@@ -1,6 +1,0 @@
----
-layout: default
----
-# Untitled test page
-
-This page should not appear in the navigation.


### PR DESCRIPTION
Pages with `nav_exclude: true` are currently sorted on `title` and `nav_order`. That can cause build failures when the type of value of the field differs from that on other pages, as reported in https://github.com/pmarsceill/just-the-docs/issues/406.

Pages with `nav_exclude: true` or no `title` are never displayed in the navigation, so removing them from `pages_list` cannot break existing sites. This change also allows the removal of some tests in the code. (The indentation of the code should now be adjusted, but that has been deferred, to restrict the size of the diff for review.)

For testing, the `title` of `404.html` has been changed to the number `404`,  the page `docs/untitled-test.md`  has been added, and `nav_sort_order` has been set to `case_sensitive`. Those updates give build failures with release 0.3.1, but not after the suggested changes.

It will still be possible for build failures to occur due to sorting fields of *non-excluded* pages with differing types of values (e.g., `nav_order` a mixture of numbers and strings). To make the code completely safe will require relatively complicated changes.