### PR TITLE
Enable auto dark mode with CSS

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ _site
 assets/css/just-the-docs-default.scss
 assets/css/just-the-docs-light.scss
 assets/css/just-the-docs-dark.scss
+assets/css/just-the-docs-autodark.scss
 assets/js/vendor/lunr.min.js
 assets/js/search-data.json
 assets/js/just-the-docs.js

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,7 @@
     "assets/css/just-the-docs-default.scss",
     "assets/css/just-the-docs-light.scss",
     "assets/css/just-the-docs-dark.scss",
+    "assets/css/just-the-docs-autodark.scss",
     "_sass/vendor/**/*.scss"
   ],
   "extends": ["stylelint-config-primer", "stylelint-config-prettier"],

--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -38,7 +38,7 @@
 
   &:hover,
   &.zeroclipboard-is-hover {
-    color: darken($link-color, 2%);
+    color: $link-color-dk-2;
   }
 
   &:hover,
@@ -46,13 +46,13 @@
   &.zeroclipboard-is-hover,
   &.zeroclipboard-is-active {
     text-decoration: none;
-    background-color: darken($base-button-color, 1%);
+    background-color: $base-button-color-dk-1;
   }
 
   &:active,
   &.selected,
   &.zeroclipboard-is-active {
-    background-color: darken($base-button-color, 3%);
+    background-color: $base-button-color-dk-3;
     background-image: none;
     box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
   }
@@ -83,7 +83,7 @@
   &:active,
   &.zeroclipboard-is-hover,
   &.zeroclipboard-is-active {
-    color: darken($link-color, 4%);
+    color: $link-color-dk-4;
     text-decoration: none;
     background-color: transparent;
     box-shadow: inset 0 0 0 3px $grey-lt-300;
@@ -102,17 +102,49 @@
 }
 
 .btn-primary {
-  @include btn-color($white, $btn-primary-color);
+  @include btn-color(
+    $white,
+    $btn-primary-color-lg-5,
+    $btn-primary-color-lg-2,
+    $btn-primary-color-dk-2,
+    $btn-primary-color-dk-4,
+    $btn-primary-color-dk-5,
+    $btn-primary-color-dk-10
+  );
 }
 
 .btn-purple {
-  @include btn-color($white, $purple-100);
+  @include btn-color(
+    $white,
+    lighten($purple-100, 5%),
+    lighten($purple-100, 2%),
+    darken($purple-100, 2%),
+    darken($purple-100, 4%),
+    darken($purple-100, 5%),
+    darken($purple-100, 10%)
+  );
 }
 
 .btn-blue {
-  @include btn-color($white, $blue-000);
+  @include btn-color(
+    $white,
+    lighten($blue-000, 5%),
+    lighten($blue-000, 2%),
+    darken($blue-000, 2%),
+    darken($blue-000, 4%),
+    darken($blue-000, 5%),
+    darken($blue-000, 10%)
+  );
 }
 
 .btn-green {
-  @include btn-color($white, $green-100);
+  @include btn-color(
+    $white,
+    lighten($green-100, 5%),
+    lighten($green-100, 2%),
+    darken($green-100, 2%),
+    darken($green-100, 4%),
+    darken($green-100, 5%),
+    darken($green-100, 10%)
+  );
 }

--- a/_sass/color_schemes/autodark.scss
+++ b/_sass/color_schemes/autodark.scss
@@ -1,0 +1,95 @@
+:root {
+  --body-background-color: #{$white};
+  --sidebar-color: #{$grey-lt-000};
+  --search-background-color: #{$white};
+  --table-background-color: #{$white};
+  --code-background-color: #{$grey-lt-000};
+  --feedback-color: #{darken($sidebar-color, 3%)};
+
+  --body-text-color: #{$grey-dk-100};
+  --body-heading-color: #{$grey-dk-300};
+  --search-result-preview-color: #{$grey-dk-000};
+  --nav-child-link-color: #{$grey-dk-100};
+
+  --link-color: #{$purple-000};
+  --link-color-dk-2: #{darken($purple-000, 2%)};
+  --link-color-dk-4: #{darken($purple-000, 4%)};
+
+  --btn-primary-color: #{$purple-100};
+  --btn-primary-color-lg-5: #{lighten($purple-100, 5)};
+  --btn-primary-color-lg-2: #{lighten($purple-100, 2)};
+  --btn-primary-color-dk-2: #{darken($purple-100, 2)};
+  --btn-primary-color-dk-4: #{darken($purple-100, 4)};
+  --btn-primary-color-dk-5: #{darken($purple-100, 5)};
+  --btn-primary-color-dk-10: #{darken($purple-100, 10)};
+
+  --base-button-color: #f7f7f7;
+  --base-button-color-dk-1: darken(#f7f7f7, 1);
+  --base-button-color-dk-3: darken(#f7f7f7, 3);
+
+  --border-color: #{$grey-lt-100};
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --body-background-color: #{$grey-dk-300};
+    --sidebar-color: #{$grey-dk-300};
+    --search-background-color: #{$grey-dk-250};
+    --table-background-color: #{$grey-dk-250};
+    --code-background-color: #{$grey-dk-250};
+    --feedback-color: #{darken($sidebar-color, 3%)};
+
+    --body-text-color: #{$grey-lt-300};
+    --body-heading-color: #{$grey-lt-000};
+    --nav-child-link-color: #{$grey-dk-000};
+    --search-result-preview-color: #{$grey-dk-000};
+
+    --link-color: #{$blue-000};
+    --link-color-dk-2: #{darken($blue-000, 2%)};
+    --link-color-dk-4: #{darken($blue-000, 4%)};
+
+    --btn-primary-color: #{$blue-200};
+    --btn-primary-color-lg-5: #{lighten($blue-200, 5)};
+    --btn-primary-color-lg-2: #{lighten($blue-200, 2)};
+    --btn-primary-color-dk-2: #{darken($blue-200, 2)};
+    --btn-primary-color-dk-4: #{darken($blue-200, 4)};
+    --btn-primary-color-dk-5: #{darken($blue-200, 5)};
+    --btn-primary-color-dk-10: #{darken($blue-200, 10)};
+
+    --base-button-color: #{$grey-dk-250};
+    --base-button-color-dk-1: #{darken($grey-dk-250, 1)};
+    --base-button-color-dk-3: #{darken($grey-dk-250, 3)};
+
+    --border-color: #{$grey-dk-200};
+  }
+}
+
+$body-background-color: var(--body-background-color);
+$sidebar-color: var(--sidebar-color);
+$search-background-color: var(--search-background-color);
+$table-background-color: var(--table-background-color);
+$code-background-color: var(--code-background-color);
+$feedback-color: var(--feedback-color);
+
+$body-text-color: var(--body-text-color);
+$body-heading-color: var(--body-heading-color);
+$nav-child-link-color: var(--nav-child-link-color);
+$search-result-preview-color: var(--search-result-preview-color);
+
+$link-color: var(--link-color);
+$link-color-dk-2: var(--link-color-dk-2);
+$link-color-dk-4: var(--link-color-dk-4);
+
+$btn-primary-color: var(--btn-primary-color);
+$btn-primary-color-lg-5: var(--btn-primary-color-lg-5);
+$btn-primary-color-lg-2: var(--btn-primary-color-lg-2);
+$btn-primary-color-dk-2: var(--btn-primary-color-dk-2);
+$btn-primary-color-dk-4: var(--btn-primary-color-dk-4);
+$btn-primary-color-dk-5: var(--btn-primary-color-dk-5);
+$btn-primary-color-dk-10: var(--btn-primary-color-dk-10);
+
+$base-button-color: var(--base-button-color);
+$base-button-color-dk-1: var(--base-button-color-dk-1);
+$base-button-color-dk-3: var(--base-button-color-dk-3);
+
+$border-color: var(--border-color);

--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -8,8 +8,20 @@ $nav-child-link-color: $grey-dk-000;
 $search-result-preview-color: $grey-dk-000;
 
 $link-color: $blue-000;
+$link-color-dk-2: darken($link-color, 2%);
+$link-color-dk-4: darken($link-color, 4%);
+
 $btn-primary-color: $blue-200;
+$btn-primary-color-lg-5: lighten($btn-primary-color, 5);
+$btn-primary-color-lg-2: lighten($btn-primary-color, 2);
+$btn-primary-color-dk-2: darken($btn-primary-color, 2);
+$btn-primary-color-dk-4: darken($btn-primary-color, 4);
+$btn-primary-color-dk-5: darken($btn-primary-color, 5);
+$btn-primary-color-dk-10: darken($btn-primary-color, 10);
+
 $base-button-color: $grey-dk-250;
+$base-button-color-dk-1: darken($base-button-color, 1%);
+$base-button-color-dk-3: darken($base-button-color, 3%);
 
 $code-background-color: $grey-dk-250;
 $search-background-color: $grey-dk-250;

--- a/_sass/color_schemes/light.scss
+++ b/_sass/color_schemes/light.scss
@@ -1,0 +1,1 @@
+// See _sass/support/variables to light theme vars definition

--- a/_sass/support/_variables.scss
+++ b/_sass/support/_variables.scss
@@ -82,8 +82,20 @@ $body-heading-color: $grey-dk-300 !default;
 $search-result-preview-color: $grey-dk-000 !default;
 $nav-child-link-color: $grey-dk-100 !default;
 $link-color: $purple-000 !default;
+$link-color-dk-2: darken($link-color, 2%) !default;
+$link-color-dk-4: darken($link-color, 4%) !default;
+
 $btn-primary-color: $purple-100 !default;
+$btn-primary-color-lg-5: lighten($btn-primary-color, 5) !default;
+$btn-primary-color-lg-2: lighten($btn-primary-color, 2) !default;
+$btn-primary-color-dk-2: darken($btn-primary-color, 2) !default;
+$btn-primary-color-dk-4: darken($btn-primary-color, 4) !default;
+$btn-primary-color-dk-5: darken($btn-primary-color, 5) !default;
+$btn-primary-color-dk-10: darken($btn-primary-color, 10) !default;
+
 $base-button-color: #f7f7f7 !default;
+$base-button-color-dk-1: darken($base-button-color, 1%);
+$base-button-color-dk-3: darken($base-button-color, 3%);
 
 //
 // Spacing

--- a/_sass/support/mixins/_buttons.scss
+++ b/_sass/support/mixins/_buttons.scss
@@ -1,27 +1,35 @@
 // Colored button
 
-@mixin btn-color($fg, $bg) {
+@mixin btn-color(
+  $fg,
+  $bg-lg-5,
+  $bg-lg-2,
+  $bg-dk-2,
+  $bg-dk-4,
+  $bg-dk-5,
+  $bg-dk-10
+) {
   color: $fg;
-  background-color: darken($bg, 2%);
-  background-image: linear-gradient(lighten($bg, 5%), darken($bg, 2%));
+  background-color: $bg-dk-2;
+  background-image: linear-gradient($bg-lg-5, $bg-dk-2);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25), 0 4px 10px rgba(0, 0, 0, 0.12);
 
   &:hover,
   &.zeroclipboard-is-hover {
     color: $fg;
-    background-color: darken($bg, 4%);
-    background-image: linear-gradient((lighten($bg, 2%), darken($bg, 4%)));
+    background-color: $bg-dk-4;
+    background-image: linear-gradient($bg-lg-2, $bg-dk-4);
   }
 
   &:active,
   &.selected,
   &.zeroclipboard-is-active {
-    background-color: darken($bg, 5%);
+    background-color: $bg-dk-5;
     background-image: none;
     box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
   }
 
   &.selected:hover {
-    background-color: darken($bg, 10%);
+    background-color: $bg-dk-10;
   }
 }

--- a/assets/css/just-the-docs-autodark.scss
+++ b/assets/css/just-the-docs-autodark.scss
@@ -1,0 +1,3 @@
+---
+---
+{% include css/just-the-docs.scss.liquid color_scheme="autodark" %}

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", "~> 2.2.15"
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "just-the-docs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hello everyone

I work on a project with both dark mode and light mode fans, so one of our requirements is support for a theme with a switch dark/light mode. 

[In the docs](https://pmarsceill.github.io/just-the-docs/docs/customization/#color-schemes) there is suggestion on how accomplish that with javascript. Unfortunately, when the selected color scheme is different from `default`, there is a quick blink every time the user changes to a different page, because the browser loads the entire html+css and then apply the color scheme change.

We found a robust solution using only CSS in [this article](https://derekkedziora.com/blog/dark-mode-revisited) (thank you @derekkedziora!). It consists in declaring both light and dark themes in the same CSS file, surounding the dark declaration with the directive `@media (prefers-color-scheme: dark){...}`. The `prefers-color-scheme` media feature is supported in [most modern browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)

In order to implement this full CSS solution, we had to change a little the Sass declaration workflow. Originally, the color scheme file replaces the declaration of a set of Sass variables that are then used along the entire set of Sass files ([dark.scss](https://github.com/pmarsceill/just-the-docs/blob/e8424986370bef104e680e1443a83e475d2fead7/_sass/color_schemes/dark.scss) is a good example on the workflow). The insertion of `@media (prefers-color-scheme: dark){...}` is not so obvious in this case, because Sass variables are evaluated in compile time and `@media` features are evaluated in run time.

The solution was the insertion of an "abstraction layer" made with CSS variables. In `autodark` mode, the Sass variables are assigned to CSS variables, that are linked to light/dark values according to a `@media (prefers-color-scheme: dark){...}` rule (this is what is happening in [autodark.scss](https://github.com/ThundeRatz/just-the-docs/blob/461e24163cf09201efb0d455a5d890c933b6d42c/_sass/color_schemes/autodark.scss)). It is important to notice that mixing Sass and CSS is a [bit tricky](https://sass-lang.com/documentation/breaking-changes/css-vars), but everything went well

At last, we stumbled in another Sass-CSS interaction problem. Sass functions (i.e. `darken()` and `lighten()`) cannot handle CSS variables, since Sass functions are evaluated at compile time and CSS variables at run time. To overcome this issue, we moved all Sass function calls to the color scheme file, so all color variations are computed and then assigned to CSS variables

The final result is a page that changes the color scheme according to the user settings

![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/1054087/113301057-f79e4980-92d4-11eb-87e3-c4dc29e915f7.gif)

**References**
- [Dark mode revisited](https://derekkedziora.com/blog/dark-mode-revisited)
- [MDN Developer @media/prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
- [Sass braking changes with CSS variables](https://sass-lang.com/documentation/breaking-changes/css-vars)